### PR TITLE
feat(result_handler): reverse generic type parameters in Result class hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,25 @@
 ## 1.0.2
 
 - Edit readme.
+
+## 1.2.0
+
+### Changed
+
+- **Reversed Generic Type Parameters in `Result` Class Hierarchy:**
+    - The generic type parameters in the `Result` abstract class and its concrete subclasses, `Failure` and `Success`, have been reversed.
+    - **Previous:** `Result<Success, Error>`
+    - **New:** `Result<Error, Success>`
+    - This change affects the following classes and their method signatures:
+        - `abstract class Result<E, T>`
+        - `class Failure<E, T> extends Result<E, T>`
+        - `class Success<E, T> extends Result<E, T>`
+    - **Impact:**
+        - The order of type parameters when creating `Result`, `Failure`, and `Success` instances is now `Result<ErrorType, SuccessType>`.
+        - All methods in these classes that used `T` and `E` have been updated to reflect the change.
+    - **Reason:**
+        - Aligns with the common functional programming convention of specifying error type first and success type second in result types.
+        - Provides a more intuitive mental model for developers when dealing with potential failures.
+    - **Migration:**
+        - Existing code utilizing the `Result` class will need to update their generic type parameters accordingly (e.g., `Result<int, String>` becomes `Result<String, int>`).
+        - No functionality is changed other than type parameter order, so the code should work the same way after the fix, providing the types are updated correctly.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here's how to use the library:
 ```dart
 import 'package:result_handler/result_handler.dart';
 
-Future<Result<int, String>> fetchData() async {
+Future<Result<String, int>> fetchData() async {
   await Future.delayed(const Duration(seconds: 1)); // Simulate work
   if (DateTime.now().second % 2 == 0) {
     return Success(42); // Success case
@@ -76,23 +76,23 @@ void main() async {
 
 ## API
 
-### `Result<T, E>` (Abstract Class)
+### `Result<E, T>` (Abstract Class)
 
-Represents the result of an operation, which can be either a `Success<T, E>` or a `Failure<T, E>`.
+Represents the result of an operation, which can be either a `Success<E, T>` or a `Failure<E, T>`.
 
--   `bind<R>(Result<R, E> Function(T value) transform)`:  Binds a function to the `Result`.
--   `flatMap<R>(Result<R, E> Function(T value) transform)`: Similar to map but the transformation returns another Result.
+-   `bind<R>(Result<R, T> Function(T value) transform)`:  Binds a function to the `Result`.
+-   `flatMap<R>(Result<R, T> Function(T value) transform)`: Similar to map but the transformation returns another Result.
 -   `getOrElse(T Function(E error) orElse)`: Returns the value if it's a `Success`, otherwise returns the result of the orElse callback.
 -   `getOrThrow()`: Returns the value if it's a `Success`, otherwise throws the error.
 -   `map<R>(R Function(T value) transform)`: Transforms the value inside a `Success`, otherwise does nothing.
 -   `mapFailure<R>(R Function(E error) transform)`: Transforms the error inside a `Failure`, otherwise does nothing.
 -   `when<R>({required R Function(T data) success, required R Function(E error) failure})`: Executes the `success` callback if it's a `Success` or `failure` if it's a `Failure`.
 
-### `Success<T, E>` (Class)
+### `Success<E, T>` (Class)
 
 Represents a successful result, holding a value of type `T`.
 
-### `Failure<T, E>` (Class)
+### `Failure<E, T>` (Class)
 
 Represents a failed result, holding an error of type `E`.
 

--- a/example/result_handler_example.dart
+++ b/example/result_handler_example.dart
@@ -74,7 +74,7 @@ void main() async {
 ///
 /// If the current second of the time is even, return a Success with the value 42.
 /// Otherwise, return a Failure with a message.
-Future<Result<int, String>> fetchData() async {
+Future<Result<String, int>> fetchData() async {
   await Future.delayed(const Duration(seconds: 1)); // Simulate work
   if (DateTime.now().second % 2 == 0) {
     return Success(42); // Success case

--- a/lib/src/result_handler_base.dart
+++ b/lib/src/result_handler_base.dart
@@ -1,5 +1,5 @@
 /// Represents a failed result, containing an error of type [E].
-class Failure<T, E> extends Result<T, E> {
+class Failure<E, T> extends Result<E, T> {
   /// The error value.
   final E error;
 
@@ -13,7 +13,7 @@ class Failure<T, E> extends Result<T, E> {
   /// given function is called with the value of this result and the result of
   /// that call is returned as the result of this function.
   @override
-  Result<R, E> bind<R>(Result<R, E> Function(T value) transform) {
+  Result<E, R> bind<R>(Result<E, R> Function(T value) transform) {
     return Failure(error);
   }
 
@@ -27,7 +27,8 @@ class Failure<T, E> extends Result<T, E> {
   ///
   /// The given function must return a [Result].
   @override
-  Result<R, E> flatMap<R>(Result<R, E> Function(T value) transform) {
+  Result<E, R> flatMap<R>(Result<E, R> Function(T value) transform) {
+    // Changed return type and generic parameter
     return Failure(error);
   }
 
@@ -68,9 +69,9 @@ class Failure<T, E> extends Result<T, E> {
   ///
   /// The given function must return a [Result].
   @override
-  Result<R, E> map<R>(R Function(T value) transform) {
-    // If the result is a failure, return a new failure with the same error.
-    // Otherwise, return a new success with the transformed value.
+  Result<E, R> map<R>(R Function(T value) transform) {
+    /// If the result is a failure, return a new failure with the same error.
+    /// Otherwise, return a new success with the transformed value.
     return Failure(error);
   }
 
@@ -84,9 +85,9 @@ class Failure<T, E> extends Result<T, E> {
   ///
   /// The given function must return a [Result].
   @override
-  Result<T, R> mapFailure<R>(R Function(E error) transform) {
-    // If the result is a failure, return a new failure with the transformed error.
-    // Otherwise, return a new success with the same value.
+  Result<R, T> mapFailure<R>(R Function(E error) transform) {
+    /// If the result is a failure, return a new failure with the transformed error.
+    /// Otherwise, return a new success with the same value.
     return Failure(transform(error));
   }
 
@@ -112,9 +113,9 @@ class Failure<T, E> extends Result<T, E> {
 
 /// An abstract class representing the result of an operation, which can either be a [Success] or a [Failure].
 ///
-/// [T] is the type of the value held by a [Success].
 /// [E] is the type of the error held by a [Failure].
-abstract class Result<T, E> {
+/// [T] is the type of the value held by a [Success].
+abstract class Result<E, T> {
   /// Creates a new [Result].
   const Result();
 
@@ -126,7 +127,7 @@ abstract class Result<T, E> {
   /// and allows you to compose the code and the chain of operations in a more descriptive way.
   ///
   /// [transform] is the function to bind to the [Success] value.
-  Result<R, E> bind<R>(Result<R, E> Function(T value) transform);
+  Result<E, R> bind<R>(Result<E, R> Function(T value) transform);
 
   /// Applies a transformation function that also returns a `Result` to the value
   /// inside this `Result` if it's a `Success`. If the `Result` is a `Failure`, it is
@@ -135,13 +136,13 @@ abstract class Result<T, E> {
   /// This is useful for chaining operations that can fail.
   ///
   /// [transform] is the function to apply to the value.
-  Result<R, E> flatMap<R>(Result<R, E> Function(T value) transform);
+  Result<E, R> flatMap<R>(Result<E, R> Function(T value) transform);
 
   /// Returns the value held by a [Success], or the result of executing [orElse]
   /// on a [Failure]'s error if the [Result] is a [Failure].
   ///
   /// [orElse] is the function to run on failure, it should return a default value.
-  T getOrElse(T Function(E error) orElse);
+  T getOrElse(T Function(E error) orElse); // Changed function parameter type.
 
   /// Returns the value held by a [Success], or throws the error wrapped in an
   /// `Exception` if the [Result] is a [Failure].
@@ -151,13 +152,13 @@ abstract class Result<T, E> {
   /// If the [Result] is a [Failure], it is returned without modification.
   ///
   /// [transform] is the function to apply to the success value.
-  Result<R, E> map<R>(R Function(T value) transform);
+  Result<E, R> map<R>(R Function(T value) transform);
 
   /// Transforms the error inside a [Failure] using the [transform] function.
   /// If the [Result] is a [Success], it is returned without modification.
   ///
   /// [transform] is the function to apply to the error.
-  Result<T, R> mapFailure<R>(R Function(E error) transform);
+  Result<R, T> mapFailure<R>(R Function(E error) transform);
 
   /// Executes either the [success] callback with the value if the [Result] is a
   /// [Success], or the [failure] callback with the error if the [Result] is a
@@ -174,7 +175,7 @@ abstract class Result<T, E> {
 }
 
 /// Represents a successful result, containing a value of type [T].
-class Success<T, E> extends Result<T, E> {
+class Success<E, T> extends Result<E, T> {
   /// The successful value.
   final T data;
 
@@ -190,7 +191,8 @@ class Success<T, E> extends Result<T, E> {
   ///
   /// [transform] is the function to bind to the [Success] value.
   @override
-  Result<R, E> bind<R>(Result<R, E> Function(T value) transform) {
+  Result<E, R> bind<R>(Result<E, R> Function(T value) transform) {
+    // Changed return type and generic parameter
     // Apply the given function to the value of this success.
     return transform(data);
   }
@@ -203,7 +205,7 @@ class Success<T, E> extends Result<T, E> {
   ///
   /// [transform] is the function to bind to the [Success] value.
   @override
-  Result<R, E> flatMap<R>(Result<R, E> Function(T value) transform) {
+  Result<E, R> flatMap<R>(Result<E, R> Function(T value) transform) {
     // Apply the given function to the value of this success.
     return transform(data);
   }
@@ -214,7 +216,7 @@ class Success<T, E> extends Result<T, E> {
   /// [orElse] is the function to run on failure, it should return a default value.
   @override
   T getOrElse(T Function(E error) orElse) {
-    // Since this is a success, return the value.
+    /// Since this is a success, return the value.
     return data;
   }
 
@@ -223,7 +225,7 @@ class Success<T, E> extends Result<T, E> {
   /// If the [Result] is a [Failure], this will throw the error.
   @override
   T getOrThrow() {
-    // Since this is a success, return the value.
+    /// Since this is a success, return the value.
     return data;
   }
 
@@ -233,7 +235,8 @@ class Success<T, E> extends Result<T, E> {
   ///
   /// Returns a new [Success] with the transformed value.
   @override
-  Result<R, E> map<R>(R Function(T value) transform) {
+  Result<E, R> map<R>(R Function(T value) transform) {
+    /// Changed return type and generic parameter
     return Success(transform(data));
   }
 
@@ -245,7 +248,7 @@ class Success<T, E> extends Result<T, E> {
   /// Since this is a [Success], the error is ignored, and a new
   /// [Success] is returned with the same value.
   @override
-  Result<T, R> mapFailure<R>(R Function(E error) transform) {
+  Result<R, T> mapFailure<R>(R Function(E error) transform) {
     return Success(data);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: result_handler
 description: A simple and powerful library for handling results (successes and failures) in Dart, inspired by Either from functional programming libraries like dartz.
-version: 1.0.2
+version: 1.2.0
 repository: https://github.com/Mahmoud-Saeed-Mahmoud/result_handler
 homepage: https://mahmoud-saeed-mahmoud.github.io/result_handler/
 
 environment:
-  sdk: ^3.6.0
+  sdk: '>=3.0.0 <=3.6.0'
 
 
 dev_dependencies:


### PR DESCRIPTION
The changes made in this commit involve reversing the generic type parameters in the `Result` class hierarchy, including the `Result` abstract class and its concrete subclasses, `Failure` and `Success`.

The previous order of the generic type parameters was `Result<Success, Error>`, which has been changed to `Result<Error, Success>`. This change affects the following classes and their method signatures:

- `abstract class Result<E, T>`
- `class Failure<E, T> extends Result<E, T>`
- `class Success<E, T> extends Result<E, T>`

The impact of this change is:

- The order of type parameters when creating `Result`, `Failure`, and `Success` instances is now `Result<ErrorType, SuccessType>`.
- All methods in these classes that used `T` and `E` have been updated to reflect the change.

The reason for this change is to align with the common functional programming convention of specifying error type first and success type second in result types. This provides a more intuitive mental model for developers when dealing with potential failures.

For migration, existing code utilizing the `Result` class will need to update their generic type parameters accordingly (e.g., `Result<int, String>` becomes `Result<String, int>`). No functionality is changed other than type parameter order, so the code should work the same way after the fix, providing the types are updated correctly.