### PR TITLE
🔖 fix(CHANGELOG.md): Update Dart SDK constraint to 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,3 @@
 - **Updated Dart SDK Constraint:**
     - Extended SDK compatibility to support version 3.6.1
     - Updated constraint from '>=3.0.0 <=3.6.0' to '>=3.0.0 <=3.6.1'
-
-## 1.2.1
-
-- **Updated Dart SDK Constraint:**
-    - Extended SDK compatibility to support version 3.6.1
-    - Updated constraint from '>=3.0.0 <=4.0.0' to '>=3.0.0 <=4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: result_handler
 description: A simple and powerful library for handling results (successes and failures) in Dart, inspired by Either from functional programming libraries like dartz.
-version: 1.2.2
+version: 1.2.1
 repository: https://github.com/Mahmoud-Saeed-Mahmoud/result_handler
 homepage: https://mahmoud-saeed-mahmoud.github.io/result_handler/
 
 environment:
-  sdk: ">=3.0.0 <=4.0.0"
+  sdk: ">=3.0.0 <=3.6.1"
 
 dev_dependencies:
   lints: ^5.0.0


### PR DESCRIPTION
Updates the Dart SDK constraint in the CHANGELOG.md file from '>=3.0.0 <=3.6.0' to '>=3.0.0 <=3.6.1' to extend the SDK compatibility to support version 3.6.1.