### PR TITLE
update-dart-sdk-constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,9 @@
 - **Updated Dart SDK Constraint:**
     - Extended SDK compatibility to support version 3.6.1
     - Updated constraint from '>=3.0.0 <=3.6.0' to '>=3.0.0 <=3.6.1'
+
+## 1.2.2
+
+- **Updated Dart SDK Constraint:**
+    - Extended SDK compatibility to support version 3.6.1
+    - Updated constraint from '>=3.0.0 <=4.0.0' to '>=3.0.0 <=4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: result_handler
 description: A simple and powerful library for handling results (successes and failures) in Dart, inspired by Either from functional programming libraries like dartz.
-version: 1.2.1
+version: 1.2.2
 repository: https://github.com/Mahmoud-Saeed-Mahmoud/result_handler
 homepage: https://mahmoud-saeed-mahmoud.github.io/result_handler/
 
 environment:
-  sdk: ">=3.0.0 <=3.6.1"
+  sdk: ">=3.0.0 <4.0.0"
 
 dev_dependencies:
   lints: ^5.0.0


### PR DESCRIPTION
Here is the pull request description based on the provided context:

```
## Update Dart SDK Constraint

### Changes
- Bumped the package version to 1.2.2
- Updated the Dart SDK constraints to support versions up to, but not including, 4.0.0
- Extended the Dart SDK compatibility to version 3.6.1 in the CHANGELOG.md file

### Motivation
These changes ensure compatibility with the latest Dart releases while maintaining support for older versions.
```