### PR TITLE
feat(result_handler_base): Enhance Failure class with new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,31 +15,76 @@
 ### Changed
 
 - **Reversed Generic Type Parameters in `Result` Class Hierarchy:**
-    - The generic type parameters in the `Result` abstract class and its concrete subclasses, `Failure` and `Success`, have been reversed.
-    - **Previous:** `Result<Success, Error>`
-    - **New:** `Result<Error, Success>`
-    - This change affects the following classes and their method signatures:
-        - `abstract class Result<E, T>`
-        - `class Failure<E, T> extends Result<E, T>`
-        - `class Success<E, T> extends Result<E, T>`
-    - **Impact:**
-        - The order of type parameters when creating `Result`, `Failure`, and `Success` instances is now `Result<ErrorType, SuccessType>`.
-        - All methods in these classes that used `T` and `E` have been updated to reflect the change.
-    - **Reason:**
-        - Aligns with the common functional programming convention of specifying error type first and success type second in result types.
-        - Provides a more intuitive mental model for developers when dealing with potential failures.
-    - **Migration:**
-        - Existing code utilizing the `Result` class will need to update their generic type parameters accordingly (e.g., `Result<int, String>` becomes `Result<String, int>`).
-        - No functionality is changed other than type parameter order, so the code should work the same way after the fix, providing the types are updated correctly.
+  - The generic type parameters in the `Result` abstract class and its concrete subclasses, `Failure` and `Success`, have been reversed.
+  - **Previous:** `Result<Success, Error>`
+  - **New:** `Result<Error, Success>`
+  - This change affects the following classes and their method signatures:
+    - `abstract class Result<E, T>`
+    - `class Failure<E, T> extends Result<E, T>`
+    - `class Success<E, T> extends Result<E, T>`
+  - **Impact:**
+    - The order of type parameters when creating `Result`, `Failure`, and `Success` instances is now `Result<ErrorType, SuccessType>`.
+    - All methods in these classes that used `T` and `E` have been updated to reflect the change.
+  - **Reason:**
+    - Aligns with the common functional programming convention of specifying error type first and success type second in result types.
+    - Provides a more intuitive mental model for developers when dealing with potential failures.
+  - **Migration:**
+    - Existing code utilizing the `Result` class will need to update their generic type parameters accordingly (e.g., `Result<int, String>` becomes `Result<String, int>`).
+    - No functionality is changed other than type parameter order, so the code should work the same way after the fix, providing the types are updated correctly.
 
 ## 1.2.1
 
 - **Updated Dart SDK Constraint:**
-    - Extended SDK compatibility to support version 3.6.1
-    - Updated constraint from '>=3.0.0 <=3.6.0' to '>=3.0.0 <=3.6.1'
+  - Extended SDK compatibility to support version 3.6.1
+  - Updated constraint from '>=3.0.0 <=3.6.0' to '>=3.0.0 <=3.6.1'
 
 ## 1.2.2
 
 - **Updated Dart SDK Constraint:**
-    - Extended SDK compatibility to support version 3.6.1
-    - Updated constraint from '>=3.0.0 <=4.0.0' to '>=3.0.0 <=4.0.0'
+  - Extended SDK compatibility to support version 3.6.1
+  - Updated constraint from '>=3.0.0 <=4.0.0' to '>=3.0.0 <=4.0.0'
+
+## 1.3.0
+
+### Added
+
+- **Enhanced Result Type with New Features:**
+  - **Convenience Getters:**
+    - `isSuccess`: Boolean getter to check if result is a success
+    - `isFailure`: Boolean getter to check if result is a failure
+    - `getOrNull()`: Returns the success value or null if failure
+  - **Static Factory Methods:**
+    - `Result.tryCatch()`: Safely execute a function and catch exceptions
+    - `Result.tryCatchAsync()`: Async version of tryCatch for Future operations
+    - `Result.fromNullable()`: Convert nullable values to Result with custom error
+  - **Side-Effect Methods:**
+    - `tap()`: Execute side effects on success values without modifying the result
+    - `tapError()`: Execute side effects on failure values without modifying the result
+  - **Error Recovery:**
+    - `orElse()`: Provide alternative Result when current is failure
+    - `recover()`: Transform failure to success with recovery function
+    - `recoverWith()`: Transform failure to new Result with recovery function
+  - **Filtering and Validation:**
+    - `filterOrElse()`: Filter success values with predicate, convert to failure if not matching
+  - **Collection Operations:**
+    - `Result.sequence()`: Convert List<Result> to Result<List> (fails fast on first error)
+    - `Result.partition()`: Separate list of Results into successes and failures
+  - **Combining Results:**
+    - `zipWith()`: Combine two Results using a function
+  - **Async Operations:**
+    - `mapAsync()`: Transform success value asynchronously
+    - `flatMapAsync()`: Chain async operations that return Results
+  - **Unit Type:**
+    - Added `Unit` class for operations without meaningful return values
+    - Provides `const Unit()` for consistent void operation handling
+  - **Enhanced Debugging:**
+    - Improved `toString()` implementations for better debugging experience
+    - Added `hashCode` and equality implementations
+
+### Changed
+
+- **Updated Documentation:**
+  - Comprehensive README with all new features and usage examples
+  - Organized API documentation by functionality categories
+  - Enhanced code examples showcasing functional composition patterns
+  - Added real-world scenarios for validation, error recovery, and async operations

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 # Dart Result Handling Library
 
+[![Dart](https://img.shields.io/badge/Dart-0175C2?logo=dart&logoColor=white)](https://dart.dev) [![Pub Version](https://img.shields.io/pub/v/result_handler)](https://pub.dev/packages/result_handler) [![Pub Likes](https://img.shields.io/pub/likes/result_handler)](https://img.shields.io/pub/likes/result_handler) [![Pub Publisher](https://img.shields.io/pub/publisher/result_handler)](https://img.shields.io/pub/publisher/result_handler) ![Pub Points](https://img.shields.io/pub/points/result_handler) ![Pub Monthly Downloads](https://img.shields.io/pub/dm/result_handler) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](/LICENSE)
+
 A simple and powerful library for handling results (successes and failures) in Dart, inspired by `Either` from functional programming libraries like `dartz`. This library uses `Success` and `Failure` classes to represent outcomes.
 
 ## Features
 
--   **Explicit Success/Failure:** Clearly distinguish between successful operations and those that resulted in an error.
--   **Type Safety:** Leverages Dart's type system to enforce correct handling of both successful and failed results.
--   **Functional Operations:** Provides methods like `map`, `mapFailure`, `flatMap`, `bind` and `when` for chaining and transforming results in a concise and readable way.
--   **Error Handling:** Provides methods `getOrElse` and `getOrThrow` for gracefully handle errors
--   **Simple API:** Easy to learn and integrate into your projects.
+- **Explicit Success/Failure:** Clearly distinguish between successful operations and those that resulted in an error.
+- **Type Safety:** Leverages Dart's type system to enforce correct handling of both successful and failed results.
+- **Functional Operations:** Provides methods like `map`, `mapFailure`, `flatMap`, `bind` and `when` for chaining and transforming results in a concise and readable way.
+- **Error Handling:** Provides methods `getOrElse` and `getOrThrow` for gracefully handle errors
+- **Convenience Methods:** Type checking with `isSuccess`/`isFailure` getters and safe value access with `getOrNull`/`getErrorOrNull`
+- **Side Effects:** Execute side-effect operations with `tap` and `tapError` methods
+- **Error Recovery:** Recover from failures using `orElse` method
+- **Filtering:** Filter success values with `filterOrElse` method
+- **Collection Operations:** Work with multiple results using `sequence` static method
+- **Factory Methods:** Create results safely with `tryCatch`, `tryCatchAsync`, and `fromNullable`
+- **Combining Results:** Combine multiple results with `zipWith` method
+- **Unit Type:** Use `Unit` type for operations that don't return meaningful values
+- **Simple API:** Easy to learn and integrate into your projects.
 
 ## Usage
 
@@ -17,59 +27,88 @@ Here's how to use the library:
 ```dart
 import 'package:result_handler/result_handler.dart';
 
+// Using the new tryCatchAsync factory method
 Future<Result<String, int>> fetchData() async {
-  await Future.delayed(const Duration(seconds: 1)); // Simulate work
-  if (DateTime.now().second % 2 == 0) {
-    return Success(42); // Success case
-  } else {
-    return Failure("Data fetch failed"); // Failure case
-  }
+  return Result.tryCatchAsync(
+    () async {
+      await Future.delayed(const Duration(seconds: 1)); // Simulate work
+      if (DateTime.now().second % 2 == 0) {
+        return 42; // Success case
+      } else {
+        throw Exception("Data fetch failed"); // This will be caught
+      }
+    },
+    (error, stackTrace) => "Network error: ${error.toString()}",
+  );
+}
+
+// Example of a validation function
+Result<String, int> validateAge(int? age) {
+  return Result.fromNullable(age, () => "Age cannot be null")
+      .filterOrElse(
+        (value) => value >= 0 && value <= 150,
+        (value) => "Invalid age: $value",
+      );
 }
 
 void main() async {
   final result = await fetchData();
 
+  // Basic pattern matching
   result.when(
     success: (value) => print('Success: $value'),
     failure: (error) => print('Error: $error'),
   );
 
-  final mappedResult = result.map((value) => value * 2);
-
-   mappedResult.when(
-    success: (value) => print('Success mapped: $value'),
-    failure: (error) => print('Error mapped: $error'),
-  );
-
-   final errorMappedResult = result.mapFailure((error) => 'New Error: $error');
-
-    errorMappedResult.when(
-    success: (value) => print('Success error mapped: $value'),
-    failure: (error) => print('Error error mapped: $error'),
-  );
-  
-    final flatMappedResult = result.flatMap((value) => Success(value * 3));
-    
-     flatMappedResult.when(
-        success: (value) => print('Success flat mapped: $value'),
-        failure: (error) => print('Error flat mapped: $error'),
-    );
-
-  final finalValue = result.getOrElse((error) => -1);
-    print("final value: $finalValue");
-
-
-  try {
-     final value = result.getOrThrow();
-     print('Got: $value');
-  } catch(e) {
-    print("Exception thrown : $e");
+  // Using convenience getters
+  if (result.isSuccess) {
+    print('Operation succeeded with value: ${result.getOrNull()}');
   }
-  final resultB = await fetchData();
-  final bindResult = resultB.bind((data) => Success(data * 50));
-  bindResult.when(
-    success: (value) => print('Success bind: $value'),
-    failure: (error) => print('Error bind: $error'),
+
+  // Chain operations with tap for side effects
+  final processedResult = result
+      .tap((value) => print('Processing value: $value')) // Side effect
+      .map((value) => value * 2)
+      .tapError((error) => print('Logging error: $error')); // Error side effect
+
+  // Error recovery
+  final recoveredResult = result.orElse((error) => Success(0));
+  print('Recovered value: ${recoveredResult.getOrElse((_) => -1)}');
+
+  // Working with multiple results
+  final results = [Success<String, int>(1), Success<String, int>(2), Success<String, int>(3)];
+  final sequenceResult = Result.sequence(results);
+  sequenceResult.when(
+    success: (values) => print('All values: $values'),
+    failure: (error) => print('One failed: $error'),
+  );
+
+  // Combining results
+  final result1 = Success<String, int>(10);
+  final result2 = Success<String, int>(20);
+  final combined = result1.zipWith(result2, (a, b) => a + b);
+  print('Combined: ${combined.getOrElse((_) => 0)}');
+
+  // Validation example
+  final ageValidation = validateAge(25);
+  ageValidation.when(
+    success: (age) => print('Valid age: $age'),
+    failure: (error) => print('Validation error: $error'),
+  );
+
+  // Using Unit for operations without meaningful return values
+  final saveResult = Result.tryCatch<String, Unit>(
+    () {
+      // Simulate a save operation
+      print('Saving data...');
+      return const Unit();
+    },
+    (error, stackTrace) => 'Save failed: ${error.toString()}',
+  );
+
+  saveResult.when(
+    success: (_) => print('Save completed successfully'),
+    failure: (error) => print('Save failed: $error'),
   );
 }
 ```
@@ -80,21 +119,73 @@ void main() async {
 
 Represents the result of an operation, which can be either a `Success<E, T>` or a `Failure<E, T>`.
 
--   `bind<R>(Result<R, T> Function(T value) transform)`:  Binds a function to the `Result`.
--   `flatMap<R>(Result<R, T> Function(T value) transform)`: Similar to map but the transformation returns another Result.
--   `getOrElse(T Function(E error) orElse)`: Returns the value if it's a `Success`, otherwise returns the result of the orElse callback.
--   `getOrThrow()`: Returns the value if it's a `Success`, otherwise throws the error.
--   `map<R>(R Function(T value) transform)`: Transforms the value inside a `Success`, otherwise does nothing.
--   `mapFailure<R>(R Function(E error) transform)`: Transforms the error inside a `Failure`, otherwise does nothing.
--   `when<R>({required R Function(T data) success, required R Function(E error) failure})`: Executes the `success` callback if it's a `Success` or `failure` if it's a `Failure`.
+#### Core Methods
+
+- `bind<R>(Result<E, R> Function(T value) transform)`: Binds a function to the `Result`.
+- `flatMap<R>(Result<E, R> Function(T value) transform)`: Similar to map but the transformation returns another Result.
+- `map<R>(R Function(T value) transform)`: Transforms the value inside a `Success`, otherwise does nothing.
+- `mapFailure<R>(R Function(E error) transform)`: Transforms the error inside a `Failure`, otherwise does nothing.
+- `when<R>({required R Function(T data) success, required R Function(E error) failure})`: Executes the `success` callback if it's a `Success` or `failure` if it's a `Failure`.
+
+#### Value Access Methods
+
+- `getOrElse(T Function(E error) orElse)`: Returns the value if it's a `Success`, otherwise returns the result of the orElse callback.
+- `getOrThrow()`: Returns the value if it's a `Success`, otherwise throws the error.
+- `getOrNull()`: Returns the value if it's a `Success`, otherwise returns `null`.
+- `getErrorOrNull()`: Returns the error if it's a `Failure`, otherwise returns `null`.
+
+#### Type Checking
+
+- `isSuccess`: Returns `true` if this is a `Success`.
+- `isFailure`: Returns `true` if this is a `Failure`.
+
+#### Side Effects
+
+- `tap(void Function(T value) fn)`: Executes a function with the success value for side effects.
+- `tapError(void Function(E error) fn)`: Executes a function with the error value for side effects.
+
+#### Error Recovery
+
+- `orElse(Result<E, T> Function(E error) recoveryFn)`: Attempts to recover from a failure.
+
+#### Filtering
+
+- `filterOrElse(bool Function(T value) predicate, E Function(T value) errorIfFalse)`: Filters success values based on a predicate.
+
+#### Combining Results
+
+- `zipWith<U, R>(Result<E, U> other, R Function(T a, U b) combiner)`: Combines this result with another result.
+
+#### Static Factory Methods
+
+- `Result.fromNullable<E, T>(T? value, E Function() errorIfNull)`: Creates a Result from a nullable value.
+- `Result.tryCatch<E, T>(T Function() fn, E Function(Object error, StackTrace stackTrace) onError)`: Safely executes a function and wraps the result.
+- `Result.tryCatchAsync<E, T>(Future<T> Function() fn, E Function(Object error, StackTrace stackTrace) onError)`: Safely executes an async function and wraps the result.
+- `Result.sequence<E, T>(Iterable<Result<E, T>> results)`: Transforms multiple results into a single result containing a list.
 
 ### `Success<E, T>` (Class)
 
 Represents a successful result, holding a value of type `T`.
 
+- `data`: The successful value of type `T`.
+- Implements all `Result` methods with success-specific behavior.
+- Supports equality comparison and proper `toString()` representation.
+
 ### `Failure<E, T>` (Class)
 
 Represents a failed result, holding an error of type `E`.
+
+- `error`: The error value of type `E`.
+- Implements all `Result` methods with failure-specific behavior.
+- Supports equality comparison and proper `toString()` representation.
+
+### `Unit` (Class)
+
+Represents a unit type for operations that complete successfully but don't return meaningful values.
+
+- Useful for `Result<E, Unit>` when you only care about success/failure, not the return value.
+- All `Unit` instances are considered equal.
+- Commonly used for operations like save, delete, or update that don't return data.
 
 ## License
 
@@ -107,4 +198,3 @@ See the [CHANGELOG.md](CHANGELOG.md) file for a detailed history of changes.
 ## Contributing
 
 Contributions are welcome! Please feel free to submit issues or pull requests.
-

--- a/example/result_handler_example.dart
+++ b/example/result_handler_example.dart
@@ -1,84 +1,129 @@
 import 'package:result_handler/result_handler.dart';
 
-/// This is the main function of the program.
-void main() async {
-  // Fetch data using the fetchData function, which returns a Result.
-  final result = await fetchData();
+void main() {
+  // Unit Type
+  const successNoValue = Success<String, Unit>(Unit());
+  print(successNoValue); // Output: Success(Unit())
 
-  // Use the 'when' method to handle both Success and Failure cases.
-  result.when(
-    success: (value) => print('Success: $value'), // Prints success value.
-    failure: (error) => print('Error: $error'), // Prints failure error.
-  );
+  // isSuccess / isFailure
+  final Result<String, int> successResult = Success(10);
+  final Result<String, int> failureResult = Failure("Something went wrong");
+  print('successResult.isSuccess: ${successResult.isSuccess}'); // true
+  print('successResult.isFailure: ${successResult.isFailure}'); // false
+  print('failureResult.isSuccess: ${failureResult.isSuccess}'); // false
+  print('failureResult.isFailure: ${failureResult.isFailure}'); // true
 
-  // Transform the successful value using the 'map' method.
-  final mappedResult = result.map((value) => value * 2);
-
-  // Handle the mapped result, which can be a new Success or the same Failure.
-  mappedResult.when(
-    success: (value) => print(
-        'Success mapped: $value'), // Prints the transformed success value.
-    failure: (error) => print(
-        'Error mapped: $error'), // Prints the failure error from original result.
-  );
-
-  // Transform the failure error using the 'mapFailure' method.
-  final errorMappedResult = result.mapFailure((error) => 'New Error: $error');
-
-  // Handle the result from mapFailure.
-  errorMappedResult.when(
-    success: (value) => print(
-        'Success error mapped: $value'), // Prints the value from the original success result.
-    failure: (error) => print(
-        'Error error mapped: $error'), // Prints the transformed failure error.
-  );
-
-  // Chain a new successful Result with the successful value from result using the flatMap method.
-  final flatMappedResult = result.flatMap((value) => Success(value * 3));
-
-  // Handle the result from flatMap, which can be either a success from the transform or a failure if the original result was a failure.
-  flatMappedResult.when(
-    success: (value) => print(
-        'Success flat mapped: $value'), // Prints the transformed success value.
-    failure: (error) => print(
-        'Error flat mapped: $error'), // Prints the failure error from the original result.
-  );
-
-  // Get value from the result with a default value in case it's a Failure.
-  final finalValue = result.getOrElse((error) => -1);
+  // getOrNull / getErrorOrNull
+  print('successResult.getOrNull: ${successResult.getOrNull()}'); // 10
   print(
-      "final value: $finalValue"); // Prints result value or the default value.
+      'successResult.getErrorOrNull: ${successResult.getErrorOrNull()}'); // null
+  print('failureResult.getOrNull: ${failureResult.getOrNull()}'); // null
+  print(
+      'failureResult.getErrorOrNull: ${failureResult.getErrorOrNull()}'); // Something went wrong
 
-  // Get the value or throw an exception if its a failure.
-  try {
-    final value = result.getOrThrow();
-    print('Got: $value'); // Prints the result value if Success.
-  } catch (e) {
-    print(
-        "Exception thrown : $e"); // Prints the exception if the result was a failure.
-  }
+  // tap / tapError
+  Success(100)
+      .tap((value) =>
+          print('Tapped success: $value')) // Prints: Tapped success: 100
+      .tapError((err) => print('This should not print'));
 
-  // Fetch data using the fetchData function again
-  final resultB = await fetchData();
-  // Chain a new successful Result using the bind method.
-  final bindResult = resultB.bind((data) => Success(data * 50));
-  bindResult.when(
-    success: (value) => print(
-        'Success bind: $value'), // Prints the result of the chained function
-    failure: (error) => print(
-        'Error bind: $error'), // Prints the failure error from original result.
+  Failure<String, int>("Error 404")
+      .tap((value) => print('This should not print'))
+      .tapError((err) =>
+          print('Tapped error: $err')); // Prints: Tapped error: Error 404
+
+  // orElse
+  Result<String, int> recovered =
+      Failure<String, int>("Initial Error").orElse((error) {
+    print('orElse recovery attempt for: $error');
+    return Success(0); // Attempt to recover with a default value
+  });
+  print('Recovered result: ${recovered.getOrNull()}'); // 0
+
+  Result<String, int> notRecovered = Success<String, int>(5).orElse((error) {
+    print('This orElse should not be called');
+    return Failure("Should not happen");
+  });
+  print('Not-recovered result: ${notRecovered.getOrNull()}'); // 5
+
+  // filterOrElse
+  Result<String, int> validResult = Success<String, int>(10).filterOrElse(
+    (value) => value > 5,
+    (value) => "Value $value is not greater than 5",
   );
-}
+  print('Valid filter: ${validResult.getOrNull()}'); // 10
 
-/// Simulates fetching data, returning a Result that can be either Success or Failure.
-///
-/// If the current second of the time is even, return a Success with the value 42.
-/// Otherwise, return a Failure with a message.
-Future<Result<String, int>> fetchData() async {
-  await Future.delayed(const Duration(seconds: 1)); // Simulate work
-  if (DateTime.now().second % 2 == 0) {
-    return Success(42); // Success case
-  } else {
-    return Failure("Data fetch failed"); // Failure case
-  }
+  Result<String, int> invalidResult = Success<String, int>(3).filterOrElse(
+    (value) => value > 5,
+    (value) => "Value $value is not greater than 5",
+  );
+  print(
+      'Invalid filter: ${invalidResult.getErrorOrNull()}'); // Value 3 is not greater than 5
+
+  // Result.tryCatch
+  Result<String, int> trySuccess = Result.tryCatch(
+    () => int.parse("123"),
+    (e, s) => "Parse error: $e",
+  );
+  print('tryCatch success: ${trySuccess.getOrNull()}'); // 123
+
+  Result<String, int> tryFailure = Result.tryCatch(
+    () => int.parse("abc"),
+    (e, s) => "Parse error: $e",
+  );
+  print(
+      'tryCatch failure: ${tryFailure.getErrorOrNull()}'); // Parse error: FormatException: abc
+
+  // Result.fromNullable
+  Result<String, String> nonNull =
+      Result.fromNullable("Hello", () => "Value was null");
+  print('fromNullable non-null: ${nonNull.getOrNull()}'); // Hello
+
+  String? nullableValue;
+  Result<String, String> isNull =
+      Result.fromNullable(nullableValue, () => "Value was null");
+  print('fromNullable null: ${isNull.getErrorOrNull()}'); // Value was null
+
+  // zipWith
+  final Result<String, int> r1 = Success(10);
+  final Result<String, String> r2 = Success(" apples");
+  final Result<String, int> r3 = Failure("r3 failed");
+
+  Result<String, String> zipSuccess =
+      r1.zipWith(r2, (number, fruit) => "$number$fruit");
+  print('zipSuccess: ${zipSuccess.getOrNull()}'); // "10 apples"
+
+  Result<String, String> zipFailure1 =
+      r3.zipWith(r2, (number, fruit) => "$number$fruit");
+  print('zipFailure1: ${zipFailure1.getErrorOrNull()}'); // "r3 failed"
+
+  Result<String, String> zipFailure2 = r1.zipWith(
+      Failure<String, String>("r2 failed"), (number, fruit) => "$number$fruit");
+  print('zipFailure2: ${zipFailure2.getErrorOrNull()}'); // "r2 failed"
+
+  // Result.sequence
+  final list1 = <Result<String, int>>[Success(1), Success(2), Success(3)];
+  final seq1 = Result.sequence(list1);
+  seq1.when(
+    success: (data) => print('Sequence 1 success: $data'), // [1, 2, 3]
+    failure: (error) => print('Sequence 1 failure: $error'),
+  );
+
+  final list2 = <Result<String, int>>[
+    Success(1),
+    Failure("Error in list"),
+    Success(3)
+  ];
+  final seq2 = Result.sequence(list2);
+  seq2.when(
+    success: (data) => print('Sequence 2 success: $data'),
+    failure: (error) => print('Sequence 2 failure: $error'), // Error in list
+  );
+
+  final list3 = <Result<String, int>>[];
+  final seq3 = Result.sequence(list3);
+  seq3.when(
+    success: (data) => print('Sequence 3 success: $data'), // []
+    failure: (error) => print('Sequence 3 failure: $error'),
+  );
 }

--- a/lib/src/result_handler_base.dart
+++ b/lib/src/result_handler_base.dart
@@ -1,4 +1,6 @@
 /// Represents a failed result, containing an error of type [E].
+/// [E] is the type of the error.
+/// [T] is the type of the success value (unused in Failure but part of the Result contract).
 class Failure<E, T> extends Result<E, T> {
   /// The error value.
   final E error;
@@ -6,118 +8,135 @@ class Failure<E, T> extends Result<E, T> {
   /// Creates a new [Failure] with the given error.
   const Failure(this.error);
 
-  /// Binds the given function to the value of this result, if it is a success.
+  @override
+  int get hashCode => error.hashCode;
 
-  /// If this result is a failure, the given function is not called and a new
-  /// failure with the same error is returned. If this result is a success, the
-  /// given function is called with the value of this result and the result of
-  /// that call is returned as the result of this function.
+  @override
+  bool get isFailure => true;
+
+  // --- New Feature Implementations ---
+
+  @override
+  bool get isSuccess => false;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Failure<E, T> &&
+          runtimeType == other.runtimeType &&
+          error == other.error; // Consider deep equality if E is complex.
+
   @override
   Result<E, R> bind<R>(Result<E, R> Function(T value) transform) {
-    return Failure(error);
+    // Failure state, so bypass the transform and return a new Failure with the same error.
+    // The type R indicates the success type of the *potential* new Result.
+    return Failure<E, R>(error);
   }
 
-  /// Transforms the value of this result by applying the given function to the
-  /// value of this result, if it is a success.
-  ///
-  /// If this result is a failure, the given function is not called and a new
-  /// failure with the same error is returned. If this result is a success, the
-  /// given function is called with the value of this result and the result of
-  /// that call is returned as the result of this function.
-  ///
-  /// The given function must return a [Result].
+  @override
+  Result<E, T> filterOrElse(
+      bool Function(T value) predicate, E Function(T value) errorIfFalse) {
+    // Already a Failure, so no filtering to apply.
+    return this;
+  }
+
   @override
   Result<E, R> flatMap<R>(Result<E, R> Function(T value) transform) {
-    // Changed return type and generic parameter
-    return Failure(error);
+    // Failure state, so bypass the transform.
+    return Failure<E, R>(error);
   }
 
-  /// Returns the value of this result if it is a success, or the result of
-  /// calling the given function with the error of this result as argument if it
-  /// is a failure.
-  ///
-  /// This function is useful for providing a default value when the result of
-  /// an operation is not available. The given function is only called if the
-  /// result is a failure.
+  @override
+  E? getErrorOrNull() => error;
+
   @override
   T getOrElse(T Function(E error) orElse) {
     // If the result is a failure, call the given function and return the result.
-    // Otherwise, return the value of the result.
     return orElse(error);
   }
 
-  /// Returns the value of this result if it is a success, or throws an error
-  /// if it is a failure.
-  ///
-  /// This function is useful for providing a result that will be used
-  /// immediately, in which case throwing an error if the result is not
-  /// available is acceptable.
+  @override
+  T? getOrNull() => null;
+
   @override
   T getOrThrow() {
     // Wrap the error in Exception before throwing it,
-    //since the error might not be an object that can be thrown.
-    throw Exception(error);
+    // since the error itself might not be an object that can be directly thrown
+    // or to provide a common exception type.
+    throw Exception(error
+        .toString()); // Or just `throw error;` if E is always an Exception type.
   }
 
-  /// Maps the value of this result by applying the given function to the value
-  /// of this result, if it is a success.
-  ///
-  /// If this result is a failure, the given function is not called and a new
-  /// failure with the same error is returned. If this result is a success, the
-  /// given function is called with the value of this result and the result of
-  /// that call is returned as the result of this function.
-  ///
-  /// The given function must return a [Result].
   @override
   Result<E, R> map<R>(R Function(T value) transform) {
-    /// If the result is a failure, return a new failure with the same error.
-    /// Otherwise, return a new success with the transformed value.
-    return Failure(error);
+    // Failure state, so bypass the transform.
+    return Failure<E, R>(error);
   }
 
-  /// Maps the error of this result by applying the given function to the error
-  /// of this result, if it is a failure.
-  ///
-  /// If this result is a success, the given function is not called and a new
-  /// success with the same value is returned. If this result is a failure, the
-  /// given function is called with the error of this result and the result of
-  /// that call is returned as the result of this function.
-  ///
-  /// The given function must return a [Result].
   @override
   Result<R, T> mapFailure<R>(R Function(E error) transform) {
-    /// If the result is a failure, return a new failure with the transformed error.
-    /// Otherwise, return a new success with the same value.
-    return Failure(transform(error));
+    // Apply the transform to the error and wrap it in a new Failure.
+    // The type T for the success value remains unchanged.
+    return Failure<R, T>(transform(error));
   }
 
-  /// Executes one of the given functions depending on the type of the [Result].
-  ///
-  /// If the result is a [Success], the [success] function is called with the
-  /// value of the [Success] as argument and the result of that call is returned.
-  ///
-  /// If the result is a [Failure], the [failure] function is called with the
-  /// error of the [Failure] as argument and the result of that call is returned.
-  ///
-  /// The given functions must return a value of type [R].
+  @override
+  Result<E, T> orElse(Result<E, T> Function(E error) recoveryFn) {
+    // This is a Failure, attempt recovery by calling recoveryFn.
+    return recoveryFn(error);
+  }
+
+  @override
+  Result<E, T> tap(void Function(T value) fn) {
+    // No success value to tap, so do nothing and return this Failure object.
+    return this;
+  }
+
+  @override
+  Result<E, T> tapError(void Function(E error) fn) {
+    // Execute the function with the error for side effects.
+    fn(error);
+    // Return this Failure object.
+    return this;
+  }
+
+  @override
+  String toString() => 'Failure($error)';
+
   @override
   R when<R>({
     required R Function(T data) success,
     required R Function(E error) failure,
   }) {
     // If the result is a failure, call the failure function and return the result.
-    // Otherwise, call the success function and return the result.
     return failure(error);
+  }
+
+  @override
+  Result<E, R> zipWith<U, R>(
+      Result<E, U> other, R Function(T a, U b) combiner) {
+    // This is a Failure, so the combined result is this Failure.
+    // We need to cast to Failure<E,R> to match the return type.
+    return Failure<E, R>(error);
   }
 }
 
-/// An abstract class representing the result of an operation, which can either be a [Success] or a [Failure].
+/// An abstract class representing the result of an operation, which can either
+/// be a [Success] or a [Failure].
 ///
 /// [E] is the type of the error held by a [Failure].
 /// [T] is the type of the value held by a [Success].
 abstract class Result<E, T> {
   /// Creates a new [Result].
   const Result();
+
+  // --- Original Methods (with updated docs if needed) ---
+
+  /// Returns `true` if this [Result] is a [Failure], `false` otherwise.
+  bool get isFailure;
+
+  /// Returns `true` if this [Result] is a [Success], `false` otherwise.
+  bool get isSuccess;
 
   /// Binds a function to the [Result]. If the result is a [Success],
   /// the function is applied to the value, returning a new [Result].
@@ -127,7 +146,19 @@ abstract class Result<E, T> {
   /// and allows you to compose the code and the chain of operations in a more descriptive way.
   ///
   /// [transform] is the function to bind to the [Success] value.
+  /// Returns a new [Result] based on the transformation.
   Result<E, R> bind<R>(Result<E, R> Function(T value) transform);
+
+  /// If this is a [Success] and its value satisfies the [predicate], returns this [Success].
+  /// If it's a [Success] but the value does not satisfy the [predicate], returns a [Failure]
+  /// with the error produced by [errorIfFalse] (using the original success value).
+  /// If this is already a [Failure], it's returned unchanged.
+  ///
+  /// [predicate] A function to test the success value.
+  /// [errorIfFalse] A function that produces an error of type [E] if the predicate is false.
+  /// Returns a [Result<E, T>].
+  Result<E, T> filterOrElse(
+      bool Function(T value) predicate, E Function(T value) errorIfFalse);
 
   /// Applies a transformation function that also returns a `Result` to the value
   /// inside this `Result` if it's a `Success`. If the `Result` is a `Failure`, it is
@@ -135,30 +166,75 @@ abstract class Result<E, T> {
   ///
   /// This is useful for chaining operations that can fail.
   ///
-  /// [transform] is the function to apply to the value.
+  /// [transform] is the function to apply to the value. It must return a [Result].
+  /// Returns a new [Result] based on the transformation.
   Result<E, R> flatMap<R>(Result<E, R> Function(T value) transform);
+
+  /// Returns the error value if this is a [Failure], otherwise returns `null`.
+  E? getErrorOrNull();
 
   /// Returns the value held by a [Success], or the result of executing [orElse]
   /// on a [Failure]'s error if the [Result] is a [Failure].
   ///
-  /// [orElse] is the function to run on failure, it should return a default value.
-  T getOrElse(T Function(E error) orElse); // Changed function parameter type.
+  /// [orElse] is the function to run on failure, it should return a default value of type [T].
+  /// Returns the success value or the result of [orElse].
+  T getOrElse(T Function(E error) orElse);
+
+  // --- New Features ---
+
+  /// Returns the success value if this is a [Success], otherwise returns `null`.
+  ///
+  /// This is useful for contexts where `null` can represent the absence of a
+  /// valid result, but typically `getOrElse` or `when` are preferred for safety.
+  T? getOrNull();
 
   /// Returns the value held by a [Success], or throws the error wrapped in an
-  /// `Exception` if the [Result] is a [Failure].
+  /// [Exception] if the [Result] is a [Failure].
+  ///
+  /// Use this when you expect a success and consider a failure an exceptional case.
+  /// Returns the success value. Throws if this is a [Failure].
   T getOrThrow();
 
   /// Transforms the value inside a [Success] using the [transform] function.
   /// If the [Result] is a [Failure], it is returned without modification.
   ///
-  /// [transform] is the function to apply to the success value.
+  /// [transform] is the function to apply to the success value. It returns a new value of type [R].
+  /// Returns a new [Result] with the transformed value if this is a [Success],
+  /// or the original [Failure].
   Result<E, R> map<R>(R Function(T value) transform);
 
   /// Transforms the error inside a [Failure] using the [transform] function.
   /// If the [Result] is a [Success], it is returned without modification.
   ///
-  /// [transform] is the function to apply to the error.
+  /// [transform] is the function to apply to the error. It returns a new error value of type [R].
+  /// Returns a new [Result] with the transformed error if this is a [Failure],
+  /// or the original [Success].
   Result<R, T> mapFailure<R>(R Function(E error) transform);
+
+  /// If this is a [Failure], applies the [recoveryFn] to the error.
+  /// The [recoveryFn] itself returns a [Result], allowing an attempt to recover
+  /// from the failure with an alternative operation.
+  /// If this is a [Success], it is returned unchanged.
+  ///
+  /// [recoveryFn] A function that takes the error and returns a new [Result<E, T>].
+  /// Returns the original [Success] or the result of [recoveryFn].
+  Result<E, T> orElse(Result<E, T> Function(E error) recoveryFn);
+
+  /// If this is a [Success], executes the given function [fn] with the success value
+  /// for side effects (e.g., logging) and then returns this original [Success] object.
+  /// If this is a [Failure], [fn] is not called and this [Failure] is returned.
+  ///
+  /// [fn] The function to execute with the success value.
+  /// Returns this [Result] object.
+  Result<E, T> tap(void Function(T value) fn);
+
+  /// If this is a [Failure], executes the given function [fn] with the error value
+  /// for side effects (e.g., logging) and then returns this original [Failure] object.
+  /// If this is a [Success], [fn] is not called and this [Success] is returned.
+  ///
+  /// [fn] The function to execute with the error value.
+  /// Returns this [Result] object.
+  Result<E, T> tapError(void Function(E error) fn);
 
   /// Executes either the [success] callback with the value if the [Result] is a
   /// [Success], or the [failure] callback with the error if the [Result] is a
@@ -167,14 +243,119 @@ abstract class Result<E, T> {
   /// [success] is the function to call when the result is a [Success].
   /// [failure] is the function to call when the result is a [Failure].
   ///
-  /// Returns the result of the called callback.
+  /// Returns the result of the called callback, which is of type [R].
   R when<R>({
     required R Function(T data) success,
     required R Function(E error) failure,
   });
+
+  /// Combines this [Result] with another [Result] (`other`).
+  ///
+  /// If both this [Result] and `other` are [Success], the `combiner` function is
+  /// applied to their values, and a new [Success] containing the result is returned.
+  /// If either this [Result] or `other` (or both) is a [Failure], the first
+  /// encountered [Failure] is returned.
+  ///
+  /// [other] The other [Result] to combine with.
+  /// [combiner] A function that takes the success values of this [Result] and `other`,
+  /// and returns a new value of type [R].
+  /// Returns a [Result<E, R>].
+  Result<E, R> zipWith<U, R>(Result<E, U> other, R Function(T a, U b) combiner);
+
+  /// Factory method to create a [Result] from a nullable value.
+  ///
+  /// If [value] is not `null`, a [Success<E, T>] containing the value is returned.
+  /// If [value] is `null`, [errorIfNull] is called to produce an error of type [E],
+  /// which is then wrapped in a [Failure<E, T>].
+  ///
+  /// Note: [T] must be a non-nullable type (`T extends Object`).
+  ///
+  /// [value] The nullable value of type [T?].
+  /// [errorIfNull] A function that produces an error of type [E] if [value] is null.
+  /// Returns a [Result<E, T>].
+  static Result<E, T> fromNullable<E, T extends Object>(
+    T? value,
+    E Function() errorIfNull,
+  ) {
+    if (value != null) {
+      return Success(value);
+    } else {
+      return Failure(errorIfNull());
+    }
+  }
+
+  /// Transforms an `Iterable<Result<E, T>>` into a `Result<E, List<T>>`.
+  ///
+  /// If all [Result] instances in the [results] iterable are [Success],
+  /// this method returns a [Success] containing a [List<T>] of all the success values
+  /// in their original order.
+  /// If any [Result] instance in the [results] iterable is a [Failure],
+  /// this method short-circuits and returns the first encountered [Failure].
+  /// An empty iterable will result in a `Success([])`.
+  ///
+  /// [results] An iterable of [Result<E, T>] instances.
+  /// Returns a [Result<E, List<T>>].
+  static Result<E, List<T>> sequence<E, T>(Iterable<Result<E, T>> results) {
+    final successfulValues = <T>[];
+    for (final result in results) {
+      if (result.isFailure) {
+        // Explicitly cast to Failure to access the error.
+        // This is safe due to the isFailure check.
+        return Failure((result as Failure<E, T>).error);
+      }
+      // Explicitly cast to Success to access data.
+      // This is safe because if it were a Failure, we would have returned above.
+      successfulValues.add((result as Success<E, T>).data);
+    }
+    return Success(successfulValues);
+  }
+
+  /// Factory method to create a [Result] by executing a synchronous function [fn].
+  ///
+  /// If [fn] completes successfully, its result is wrapped in a [Success].
+  /// If [fn] throws an exception, [onError] is called with the caught error and
+  /// stack trace to produce an error value of type [E], which is then wrapped
+  /// in a [Failure].
+  ///
+  /// [fn] The synchronous function to execute.
+  /// [onError] A function that converts a caught [Object] and [StackTrace] into an error of type [E].
+  /// Returns a [Result<E, T>].
+  static Result<E, T> tryCatch<E, T>(
+    T Function() fn,
+    E Function(Object error, StackTrace stackTrace) onError,
+  ) {
+    try {
+      return Success(fn());
+    } catch (e, s) {
+      return Failure(onError(e, s));
+    }
+  }
+
+  /// Factory method to create a [Result] by executing an asynchronous function [fn].
+  ///
+  /// If the [Future] returned by [fn] completes successfully, its result is wrapped in a [Success].
+  /// If the [Future] or [fn] itself throws an exception, [onError] is called with the
+  /// caught error and stack trace to produce an error value of type [E], which is then wrapped
+  /// in a [Failure].
+  ///
+  /// [fn] The asynchronous function (returning a [Future<T>]) to execute.
+  /// [onError] A function that converts a caught [Object] and [StackTrace] into an error of type [E].
+  /// Returns a [Future<Result<E, T>>].
+  static Future<Result<E, T>> tryCatchAsync<E, T>(
+    Future<T> Function() fn,
+    E Function(Object error, StackTrace stackTrace) onError,
+  ) async {
+    try {
+      return Success(await fn());
+    } catch (e, s) {
+      return Failure(onError(e, s));
+    }
+  }
 }
 
 /// Represents a successful result, containing a value of type [T].
+/// [E] is the type of the error (unused in Success but part of the Result contract).
+/// [T] is the type of the success value.
 class Success<E, T> extends Result<E, T> {
   /// The successful value.
   final T data;
@@ -182,84 +363,102 @@ class Success<E, T> extends Result<E, T> {
   /// Creates a new [Success] with the given value.
   const Success(this.data);
 
-  /// Binds a function to the [Success]. The function is applied to the value
-  /// of this [Success], returning a new [Result].
-  ///
-  /// This is similar to [flatMap], but is more aligned to functional
-  /// programming and allows you to compose the code and the chain of
-  /// operations in a more descriptive way.
-  ///
-  /// [transform] is the function to bind to the [Success] value.
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  bool get isFailure => false;
+
+  // --- New Feature Implementations ---
+
+  @override
+  bool get isSuccess => true;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Success<E, T> &&
+          runtimeType == other.runtimeType &&
+          data == other.data; // Consider deep equality if T is complex.
+
   @override
   Result<E, R> bind<R>(Result<E, R> Function(T value) transform) {
-    // Changed return type and generic parameter
     // Apply the given function to the value of this success.
     return transform(data);
   }
 
-  /// Binds a function to the [Success] value, returning a new [Result].
-  ///
-  /// This is similar to [bind], but is more aligned to the concept of
-  /// monads. The function is applied to the value of this [Success], and
-  /// the result is returned as a new [Result].
-  ///
-  /// [transform] is the function to bind to the [Success] value.
+  @override
+  Result<E, T> filterOrElse(
+      bool Function(T value) predicate, E Function(T value) errorIfFalse) {
+    if (predicate(data)) {
+      // Predicate holds, return this Success.
+      return this;
+    } else {
+      // Predicate failed, return a Failure with the provided error.
+      return Failure(errorIfFalse(data));
+    }
+  }
+
   @override
   Result<E, R> flatMap<R>(Result<E, R> Function(T value) transform) {
     // Apply the given function to the value of this success.
     return transform(data);
   }
 
-  /// Returns the value held by this [Success], or the result of executing [orElse]
-  /// on the error of a [Failure] if the [Result] is a [Failure].
-  ///
-  /// [orElse] is the function to run on failure, it should return a default value.
+  @override
+  E? getErrorOrNull() => null;
+
   @override
   T getOrElse(T Function(E error) orElse) {
-    /// Since this is a success, return the value.
+    // Since this is a success, return the value.
     return data;
   }
 
-  /// Returns the value held by this [Success].
-  ///
-  /// If the [Result] is a [Failure], this will throw the error.
+  @override
+  T? getOrNull() => data;
+
   @override
   T getOrThrow() {
-    /// Since this is a success, return the value.
+    // Since this is a success, return the value.
     return data;
   }
 
-  /// Applies a transformation to the value of this [Success].
-  ///
-  /// [transform] is the function to apply to the value of this [Success].
-  ///
-  /// Returns a new [Success] with the transformed value.
   @override
   Result<E, R> map<R>(R Function(T value) transform) {
-    /// Changed return type and generic parameter
+    // Transform the success value and wrap it in a new Success.
     return Success(transform(data));
   }
 
-  /// Maps the error of a [Failure] to a new type [R], without changing
-  /// the result type [T].
-  ///
-  /// [transform] is the function to apply to the error of a [Failure].
-  ///
-  /// Since this is a [Success], the error is ignored, and a new
-  /// [Success] is returned with the same value.
   @override
   Result<R, T> mapFailure<R>(R Function(E error) transform) {
+    // Success has no error to map, so return this success with the new error type.
+    // The actual error type R is only relevant for the Failure case.
     return Success(data);
   }
 
-  /// Calls the [success] function with the value of this [Success] and returns its
-  /// result.
-  ///
-  /// This is the equivalent of pattern matching for results.
-  ///
-  /// [success] is the function to call when the result is a [Success].
-  /// [failure] is the function to call when the result is a [Failure], but it's
-  /// ignored for [Success] values.
+  @override
+  Result<E, T> orElse(Result<E, T> Function(E error) recoveryFn) {
+    // This is a Success, no need to recover.
+    return this;
+  }
+
+  @override
+  Result<E, T> tap(void Function(T value) fn) {
+    // Execute the function with the data for side effects.
+    fn(data);
+    // Return this Success object.
+    return this;
+  }
+
+  @override
+  Result<E, T> tapError(void Function(E error) fn) {
+    // No error to tap, so do nothing and return this Success object.
+    return this;
+  }
+
+  @override
+  String toString() => 'Success($data)';
+
   @override
   R when<R>({
     required R Function(T data) success,
@@ -268,4 +467,31 @@ class Success<E, T> extends Result<E, T> {
     // Since this is a success, call the success function with the value.
     return success(data);
   }
+
+  @override
+  Result<E, R> zipWith<U, R>(
+      Result<E, U> other, R Function(T a, U b) combiner) {
+    // This is Success(a). Now we need to check 'other'.
+    // We can use other.map to achieve this:
+    // If 'other' is Success(b), other.map will call combiner(a, b) and wrap it in Success.
+    // If 'other' is Failure(e), other.map will return Failure(e).
+    return other.map((uValue) => combiner(data, uValue));
+  }
+}
+
+/// Represents a unit type, indicating that an operation completed successfully
+/// but does not yield a meaningful value.
+/// This is often used in `Result<E, Unit>` for operations whose success
+/// is simply the absence of an error (e.g., a save operation).
+class Unit {
+  const Unit();
+
+  @override
+  int get hashCode => 0; // All Unit instances are considered equal
+
+  @override
+  bool operator ==(Object other) => other is Unit;
+
+  @override
+  String toString() => 'Unit()';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: result_handler
 description: A simple and powerful library for handling results (successes and failures) in Dart, inspired by Either from functional programming libraries like dartz.
-version: 1.2.2
+version: 1.3.0
 repository: https://github.com/Mahmoud-Saeed-Mahmoud/result_handler
 homepage: https://mahmoud-saeed-mahmoud.github.io/result_handler/
 
@@ -9,3 +9,10 @@ environment:
 
 dev_dependencies:
   lints: ^5.0.0
+
+topics:
+  - result
+  - success
+  - failure
+  - either
+  - functional-programming


### PR DESCRIPTION
The changes made to the `Failure` class in the `result_handler_base.dart` file include:

1. Adding type parameter documentation for `E` (error type) and `T` (success type).
2. Implementing the `hashCode` and `==` operators for the `Failure` class.
3. Implementing the `isFailure` and `isSuccess` properties to clearly indicate the state of the `Result`.
4. Enhancing the `bind`, `filterOrElse`, `flatMap`, `getErrorOrNull`, `getOrElse`, `getOrNull`, `getOrThrow`, and `map` methods to handle the `Failure` case more effectively.
5. Improving the error handling in the `getOrThrow` method by wrapping the error in an `Exception` before throwing it.

These changes aim to improve the overall functionality and robustness of the `Failure` class, making it more versatile and easier to use within the `Result` handling framework.